### PR TITLE
Error when using both $inlinecount & $select : Not all identifier properties can be found in the ResultSetMapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.3.2",
         "doctrine/orm": ">=2.4",
         "jms/serializer": "~1.0",
-        "adrotec/odataphpprod": "1.0.*"
+        "adrotec/odataphpprod": "dev-master"
     },
     "suggest": {
         "symfony/validator": "Enable Validation"

--- a/src/Adrotec/BreezeJs/Doctrine/ORM/QueryService.php
+++ b/src/Adrotec/BreezeJs/Doctrine/ORM/QueryService.php
@@ -43,6 +43,7 @@ class QueryService {
         
         if ($fetchJoinCollection || $fetchCount) {
             $paginator = new Paginator($query, $fetchJoinCollection);
+            $paginator->setUseOutputWalkers(false);
             if ($fetchCount) {
                 $inlineCount = count($paginator);
             }


### PR DESCRIPTION
Error "Not all identifier properties can be found in the ResultSetMapping" has been fixed in Doctrine 2.5
